### PR TITLE
Add missing <stdexcept> header for std::invalid_argument

### DIFF
--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <exception>
+#include <stdexcept>
 #include <functional>
 #include <memory>
 #include <set>


### PR DESCRIPTION
```cpp
In file included from crypto/equihash.cpp:20:
./crypto/equihash.h: In function ‘bool EhBasicSolve(unsigned int, unsigned int, const eh_HashState&, std::function<bool(std::vector<unsigned char>)>, std::function<bool(EhSolverCancelCheck)>)’:
./crypto/equihash.h:235:20: error: ‘invalid_argument’ is not a member of ‘std’
  235 |         throw std::invalid_argument("Unsupported Equihash parameters");
      |                    ^~~~~~~~~~~~~~~~
./crypto/equihash.h: In function ‘bool EhOptimisedSolve(unsigned int, unsigned int, const eh_HashState&, std::function<bool(std::vector<unsigned char>)>, std::function<bool(EhSolverCancelCheck)>)’:
./crypto/equihash.h:261:20: error: ‘invalid_argument’ is not a member of ‘std’
  261 |         throw std::invalid_argument("Unsupported Equihash parameters");
      |                    ^~~~~~~~~~~~~~~~
make[2]: *** [Makefile:3069: crypto/libbitcoin_crypto_a-equihash.o] Error 1
```

To compile on Fedora 32 with gcc version 10.2.1, needs to include \<stdexcept\>.