### PR TITLE
Make deprecation height different between mainnet, testnet and regtest

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -84,6 +84,7 @@ public:
         strCurrencyUnits = "ZER";
         bip44CoinType = 323; // As registered in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
         consensus.fCoinbaseMustBeProtected = true;
+        consensus.nApproxReleaseHeight = 886075;
         consensus.nFeeStartBlockHeight = 412300;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_HALVING_INTERVAL;
         consensus.nPostBlossomSubsidyHalvingInterval = Consensus::POST_BLOSSOM_HALVING_INTERVAL;
@@ -254,6 +255,7 @@ public:
         strCurrencyUnits = "ZET";
         bip44CoinType = 1;
         consensus.fCoinbaseMustBeProtected = true;
+        consensus.nApproxReleaseHeight = 886075;
         consensus.nFeeStartBlockHeight = 1;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_HALVING_INTERVAL;
         consensus.nPostBlossomSubsidyHalvingInterval = Consensus::POST_BLOSSOM_HALVING_INTERVAL;
@@ -413,6 +415,7 @@ public:
         strCurrencyUnits = "REG";
         bip44CoinType = 1;
         consensus.fCoinbaseMustBeProtected = false;
+        consensus.nApproxReleaseHeight = std::numeric_limits<int>::max(); // Disabled on regtest
         consensus.nFeeStartBlockHeight = 5000;
         consensus.nPreBlossomSubsidyHalvingInterval = Consensus::PRE_BLOSSOM_REGTEST_HALVING_INTERVAL;
         consensus.nPostBlossomSubsidyHalvingInterval = Consensus::POST_BLOSSOM_REGTEST_HALVING_INTERVAL;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -118,6 +118,9 @@ struct Params {
     int nPreBlossomSubsidyHalvingInterval;
     int nPostBlossomSubsidyHalvingInterval;
 
+    /** Deprecation block height */
+    int nApproxReleaseHeight;
+
     int Halving(int nHeight) const;
 
     int GetLastFoundersRewardBlockHeight(int nHeight) const;

--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <exception>
+#include <stdexcept>
 #include <functional>
 #include <memory>
 #include <set>

--- a/src/deprecation.h
+++ b/src/deprecation.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2017 The Zcash developers
+// Copyright (c) 2017-2020 The LitecoinZ Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
@@ -6,25 +7,40 @@
 #define ZCASH_DEPRECATION_H
 
 // Deprecation policy:
-// * Shut down 26 weeks' worth of blocks after the estimated release block height.
-// * A warning is shown during the 4 weeks' worth of blocks prior to shut down.
-static const int APPROX_RELEASE_HEIGHT = 886075;
-static const int WEEKS_UNTIL_DEPRECATION = 26;
-//Fixing zero day size
-static const int DEPRECATION_HEIGHT = APPROX_RELEASE_HEIGHT + (WEEKS_UNTIL_DEPRECATION * 7 * 24 * 30);
+// Shut down nodes running this version of code, 16 weeks' worth of blocks after the estimated
+// release block height. A warning is shown during the 14 days' worth of blocks prior to shut down.
+static const int RELEASE_TO_DEPRECATION_WEEKS = 16;
+
+// Expected number of blocks per hour
+static const int EXPECTED_BLOCKS_PER_HOUR = 30;
 
 // Number of blocks before deprecation to warn users
-//Fixing zero day size
-static const int DEPRECATION_WARN_LIMIT = 28 * 24 * 30; // 4 weeks
+static const int DEPRECATION_WARN_LIMIT = 14 * 24 * EXPECTED_BLOCKS_PER_HOUR;
 
-/**
- * Checks whether the node is deprecated based on the current block height, and
- * shuts down the node with an error if so (and deprecation is not disabled for
- * the current client version). Warning and error messages are sent to the debug
- * log, the metrics UI, and (if configured) -alertnofity.
- *
- * fThread means run -alertnotify in a free-running thread.
- */
-void EnforceNodeDeprecation(int nHeight, bool forceLogging=false, bool fThread=true);
+class CDeprecation
+{
+protected:
+    int nDeprecationHeight;
+
+public:
+    CDeprecation(const int approxreleaseheight);
+    ~CDeprecation();
+
+    /** Return deprecation height */
+    int getDeprecationHeight();
+
+    /**
+     * Checks whether the node is deprecated based on the current block height, and
+     * shuts down the node with an error if so (and deprecation is not disabled for
+     * the current client version). Warning and error messages are sent to the debug
+     * log, the metrics UI, and (if configured) -alertnofity.
+     *
+     * fThread means run -alertnotify in a free-running thread.
+     */
+    void EnforceNodeDeprecation(int nHeight, bool forceLogging = false, bool fThread=true);
+
+private:
+    int approxreleaseheight_;
+};
 
 #endif // ZCASH_DEPRECATION_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3559,7 +3559,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
     // Update cached incremental witnesses
     GetMainSignals().ChainTip(pindexNew, pblock, oldSproutTree, oldSaplingTree, true);
 
-    EnforceNodeDeprecation(pindexNew->nHeight);
+    CDeprecation deprecation = CDeprecation(Params().GetConsensus().nApproxReleaseHeight);
+    deprecation.EnforceNodeDeprecation(pindexNew->nHeight);
 
     int64_t nTime6 = GetTimeMicros(); nTimePostConnect += nTime6 - nTime5; nTimeTotal += nTime6 - nTime1;
     LogPrint("bench", "  - Connect postprocess: %.2fms [%.2fs]\n", (nTime6 - nTime5) * 0.001, nTimePostConnect * 0.000001);
@@ -5089,7 +5090,8 @@ bool static LoadBlockIndexDB()
         DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
         Checkpoints::GuessVerificationProgress(chainparams.Checkpoints(), chainActive.Tip()));
 
-    EnforceNodeDeprecation(chainActive.Height(), true);
+    CDeprecation deprecation = CDeprecation(Params().GetConsensus().nApproxReleaseHeight);
+    deprecation.EnforceNodeDeprecation(chainActive.Height(), true);
 
     return true;
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -421,7 +421,8 @@ UniValue getdeprecationinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("version", CLIENT_VERSION));
     obj.push_back(Pair("subversion",
         FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<string>())));
-    obj.push_back(Pair("deprecationheight", DEPRECATION_HEIGHT));
+    CDeprecation deprecation = CDeprecation(Params().GetConsensus().nApproxReleaseHeight);
+    obj.pushKV("deprecationheight", deprecation.getDeprecationHeight());
 
     return obj;
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1034,16 +1034,16 @@ UniValue signrawtransaction(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid sighash param");
     }
 
+    const Consensus::Params& consensusParams = Params().GetConsensus();
+
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
     // Use the approximate release height if it is greater so offline nodes
     // have a better estimation of the current height and will be more likely to
-    // determine the correct consensus branch ID.  Regtest mode ignores release height.
-    int chainHeight = chainActive.Height() + 1;
-    if (Params().NetworkIDString() != "regtest") {
-        chainHeight = std::max(chainHeight, APPROX_RELEASE_HEIGHT);
-    }
+    // determine the correct consensus branch ID.
+    int chainHeight = std::max(chainActive.Height() + 1, consensusParams.nApproxReleaseHeight);
+
     // Grab the current consensus branch ID
-    auto consensusBranchId = CurrentEpochBranchId(chainHeight, Params().GetConsensus());
+    auto consensusBranchId = CurrentEpochBranchId(chainHeight, consensusParams);
 
     if (params.size() > 4 && !params[4].isNull()) {
         consensusBranchId = ParseHexToUInt32(params[4].get_str());


### PR DESCRIPTION
This close #3534, #3642 and #3658

```bash
./zero-gtest --gtest_filter=DeprecationTest
Note: Google Test filter = DeprecationTest
[==========] Running 0 tests from 0 test cases.
[==========] 0 tests from 0 test cases ran. (0 ms total)
[  PASSED  ] 0 tests.
```